### PR TITLE
adding logic to only replace embedded roles

### DIFF
--- a/lib/stackops/lambdaRole.js
+++ b/lib/stackops/lambdaRole.js
@@ -43,12 +43,15 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	// Replace references
 	const functions = _.filter(stageStack.Resources, ['Type', 'AWS::Lambda::Function']);
 	_.forEach(functions, func => {
-		func.Properties.Role = {
-			'Fn::GetAtt': [
-				roleLogicalId,
-				'Arn'
-			]
-		};
+		// only replace embedded roles.
+		if (_.has(func.Properties.Role, 'Fn::GetAtt')) {
+			func.Properties.Role = {
+				'Fn::GetAtt': [
+					roleLogicalId,
+					'Arn'
+				]
+			};
+		}
 		const dependencyIndex = _.indexOf(func.DependsOn, 'IamRoleLambdaExecution');
 		func.DependsOn[dependencyIndex] = roleLogicalId;
 	});


### PR DESCRIPTION
Closes #87. The thinking behind this is to replace only embedded roles.  If one is overridden with import value, or full ARN, use those values instead. 

Could still need to modify to account for other intrinsic cloudformation functions (Ref, Join) if they call back to the roleLogicalId. 
  