### PR TITLE
Clarify install for less-experienced npm users

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,20 @@ protecting the aliased function versions, and many more.
 ## Installation
 
 Add the plugin to your package.json's devDependencies and to the plugins array
-in your `serverless.yml` file. After installation the plugin will automatically
-hook into the deployment process.
-Additionally the new `alias` command is added to Serverless which offers some
-functionality for aliases.
+in your `serverless.yml` file
+
+Terminal:
+```
+npm install --save-dev serverless-aws-alias
+```
+
+serverless.yml:
+```
+plugins:
+  - serverless-aws-alias
+```
+
+After installation the plugin will automatically hook into the deployment process. Additionally the new `alias` command is added to Serverless which offers some functionality for aliases.
 
 ## Deploy the default alias
 


### PR DESCRIPTION
The serverless framework makes use of npm, but is designed to allow deployment to services such as AWS which support a variety of languages. As a result, there are users utilizing the serverless tool who are not as familiar with npm commands. 

This change adds the explicit command syntax needed to accomplish the installation to the README install instructions