### PR TITLE
fix the case of per-function custom Role

### DIFF
--- a/lib/stackops/lambdaRole.js
+++ b/lib/stackops/lambdaRole.js
@@ -43,14 +43,16 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 	// Replace references
 	const functions = _.filter(stageStack.Resources, ['Type', 'AWS::Lambda::Function']);
 	_.forEach(functions, func => {
-		func.Properties.Role = {
-			'Fn::GetAtt': [
-				roleLogicalId,
-				'Arn'
-			]
-		};
-		const dependencyIndex = _.indexOf(func.DependsOn, 'IamRoleLambdaExecution');
-		func.DependsOn[dependencyIndex] = roleLogicalId;
+		if (_.isEqual(func.Properties.Role, { 'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn' ]})) {
+			func.Properties.Role = {
+				'Fn::GetAtt': [
+					roleLogicalId,
+					'Arn'
+				]
+			};
+			const dependencyIndex = _.indexOf(func.DependsOn, 'IamRoleLambdaExecution');
+			func.DependsOn[dependencyIndex] = roleLogicalId;
+		}
 	});
 
 	if (_.has(currentTemplate, 'Resources.IamRoleLambdaExecution')) {


### PR DESCRIPTION
I had a trouble with per-function custom Role, and needed to fix it.

I llooked around issues and pull requests, and found #87 and #88.
My custom role is in the same stack, so @bencodner 's solution does not apply.
So, I wrote another patch. It will cover cross-stack cases.
