### PR TITLE
Supporting dash in alias name when creating api gateway authorizers

### DIFF
--- a/lib/removeAlias.js
+++ b/lib/removeAlias.js
@@ -60,7 +60,7 @@ module.exports = {
 
 			// Check for aliased authorizers thhat reference a removed function
 			_.forEach(obsoleteFuncRefs, obsoleteFuncRef => {
-				const authorizerName = `${obsoleteFuncRef}ApiGatewayAuthorizer${this._alias}`;
+				const authorizerName = `${obsoleteFuncRef}ApiGatewayAuthorizer${_.replace(this._alias, /-/g, 'Dash')}`;
 				if (_.has(currentTemplate.Resources, authorizerName)) {
 					// find obsolete references
 					const authRefs = utils.findReferences(currentTemplate.Resources, authorizerName);

--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -254,7 +254,7 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 				delete userResources.Resources[name];
 			}
 
-			const aliasedName = `${name}${this._alias}`;
+			const aliasedName = `${name}${_.replace(this._alias, /-/g, 'Dash')}`;
 			const authorizerRefs = utils.findReferences(stageStack.Resources, name);
 			_.forEach(authorizerRefs, ref => {
 				_.set(stageStack.Resources, ref, { Ref: aliasedName });


### PR DESCRIPTION
Replacing the `-` in the alias for the API Gateway template name. Without this change, chosing an alias name with `-` in it while your definition has an API Gateway with authorizers in it will fail.