### PR TITLE
allow configurable master alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ functionality for aliases.
 ## Deploy the default alias
 
 The default alias (for the stage) is deployed just by doing a standard stage
-deployment with `serverless deploy`. From now on you can reference the aliased
-versions on Lambda invokes with the stage qualifier. The aliased version is
-read only in the AWS console, so it is guaranteed that the environment and
-function parameters (memory, etc.) cannot be changed for a deployed version
-by accident, as it can be done with the `$LATEST` qualifier.
-This adds an additional level of stability to your deployment process.
+deployment with `serverless deploy`. By default the alias is set to the stage
+name. Optionally you can set the name of the default (master) alias using the
+option `--masterAlias`, e.g., `serverless deploy --masterAlias`. (If you have
+already created a serverless deployment without manually setting the default
+alias, this option should not be used.)
+From now on you can reference the aliased versions on Lambda invokes with the
+stage qualifier. The aliased version is read only in the AWS console, so it is
+guaranteed that the environment and function parameters (memory, etc.) cannot
+be changed for a deployed version by accident, as it can be done with the 
+`$LATEST` qualifier.This adds an additional level of stability to your deployment
+process.
 
 ## Deploy a single function
 

--- a/lib/aliasRestructureStack.js
+++ b/lib/aliasRestructureStack.js
@@ -73,15 +73,30 @@ module.exports = {
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]);
 	},
 
-	aliasRestructureStack(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+	addMasterAliasName(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
+		const stageStack = this._serverless.service.provider.compiledCloudFormationTemplate;
+		if (stageStack && !stageStack.Outputs.MasterAliasName) {
+			const masterAlias = this._masterAlias || currentTemplate.Outputs.MasterAliasName.Value;
+			stageStack.Outputs.MasterAliasName = {
+				Description: 'Master Alias name (serverless-aws-alias plugin)',
+				Value: masterAlias,
+				Export: {
+					Name: `${this._provider.naming.getStackName()}-MasterAliasName`
+				}
+			};
+		}
+		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]);
+	},
 
+	aliasRestructureStack(currentTemplate, aliasStackTemplates, currentAliasStackTemplate) {
 		this._serverless.cli.log('Preparing alias ...');
 
-		if (_.isEmpty(aliasStackTemplates) && this._stage !== this._alias) {
-			throw new this._serverless.classes.Error(new Error('You have to deploy the master alias at least once with "serverless deploy"'));
+		if (_.isEmpty(aliasStackTemplates) && this._masterAlias !== this._alias) {
+			throw new this._serverless.classes.Error(new Error('You have to deploy the master alias at least once with "serverless deploy [--masterAlias]"'));
 		}
 
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]).bind(this)
+		.spread(this.addMasterAliasName)
 		.spread(this.aliasInit)
 		.spread(this.aliasHandleUserResources)
 		.spread(this.aliasHandleLambdaRole)

--- a/lib/removeAlias.js
+++ b/lib/removeAlias.js
@@ -221,26 +221,27 @@ module.exports = {
 			this._serverless.cli.log('noDeploy option active - will do nothing');
 			return BbPromise.resolve();
 		}
-
-		if (this._stage && this._stage === this._alias) {
+		
+		this._masterAlias = currentTemplate.Outputs.MasterAliasName.Value;
+		if (this._stage && this._masterAlias === this._alias) {
 			// Removal of the master alias is requested -> check if any other aliases are still deployed.
 			const aliases = _.map(aliasStackTemplates, aliasTemplate => _.get(aliasTemplate, 'Outputs.ServerlessAliasName.Value'));
 			if (!_.isEmpty(aliases)) {
-				throw new this._serverless.classes.Error(`Remove the other deployed aliases before removing the service: ${_.without(aliases, this._alias)}`);
+				throw new this._serverless.classes.Error(`Remove the other deployed aliases before removing the service: ${_.without(aliases, this._masterAlias)}`);
 			}
 			if (_.isEmpty(currentAliasStackTemplate)) {
-				throw new this._serverless.classes.Error(`Internal error: Stack for master alias ${this._alias} is not deployed. Try to solve the problem by manual interaction with the AWS console.`);
+				throw new this._serverless.classes.Error(`Internal error: Stack for master alias ${this._masterAlias} is not deployed. Try to solve the problem by manual interaction with the AWS console.`);
 			}
 
 			// We're ready for removal
-			this._serverless.cli.log(`Removing master alias and stage ${this._alias} ...`);
+			this._serverless.cli.log(`Removing master alias and stage ${this._masterAlias} ...`);
 
 			return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]).bind(this)
 			.spread(this.aliasRemoveAliasStack)
 			.then(() => this._serverless.pluginManager.spawn('remove'));
 		}
 
-		this._serverless.cli.log(`Removing alias ${this._alias} ...`);
+		this._serverless.cli.log(`Removing alias ${this._masterAlias} ...`);
 
 		return BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]).bind(this)
 		.spread(this.aliasCreateStackChanges)

--- a/lib/stackops/apiGateway.js
+++ b/lib/stackops/apiGateway.js
@@ -278,6 +278,7 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 		// Adjust permission to reference the function aliases
 		_.forOwn(apiLambdaPermissions, (permission, name) => {
 			const functionName = _.replace(name, /LambdaPermissionApiGateway$/, '');
+
 			const versionName = utils.getFunctionVersionName(versions, functionName);
 			const aliasName = utils.getAliasVersionName(aliases, functionName);
 			const isExternalRef = isExternalRefAuthorizerPredicate(permission.Properties.FunctionName);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -17,7 +17,8 @@ module.exports = {
 
 		// Set configuration
 		this._stage = this._provider.getStage();
-		this._alias = this._options.alias || this._stage;
+		this._masterAlias = this._options.masterAlias || this._stage;
+		this._alias = this._options.alias || this._masterAlias;
 		this._stackName = this._provider.naming.getStackName();
 
 		// Make alias available as ${self:provider.alias}

--- a/test/data/sls-stack-2.json
+++ b/test/data/sls-stack-2.json
@@ -322,6 +322,13 @@
           ]
         ]
       }
+    },
+    "MasterAliasName": {
+      "Description": "Master Alias name (serverless-aws-alias plugin)",
+      "Value": "master",
+      "Export": {
+        "Name": "sls-test-project-dev-master"
+      }
     }
   }
 }

--- a/test/removeAlias.test.js
+++ b/test/removeAlias.test.js
@@ -90,7 +90,10 @@ describe('removeAlias', () => {
 
 		it('should error if an alias is deployed on stage removal', () => {
 			awsAlias._options = { alias: 'myStage' };
-			awsAlias._alias = 'myStage';
+			awsAlias._alias = 'master';
+			slsStack1.Outputs.MasterAliasName = {
+				Value: 'master'
+			};
 
 			expect(() => awsAlias.removeAlias(slsStack1, [ aliasStack1 ], aliasStack2)).to.throw(/myAlias/);
 			return BbPromise.all([
@@ -103,7 +106,10 @@ describe('removeAlias', () => {
 
 		it('should error if the master alias is not deployed on stage removal', () => {
 			awsAlias._options = { alias: 'myStage' };
-			awsAlias._alias = 'myStage';
+			awsAlias._alias = 'master';
+			slsStack1.Outputs.MasterAliasName = {
+				Value: 'master'
+			};
 
 			expect(() => awsAlias.removeAlias(slsStack1, [], {})).to.throw(/Internal error/);
 			return BbPromise.all([
@@ -116,7 +122,10 @@ describe('removeAlias', () => {
 
 		it('should remove alias and service stack on stage removal', () => {
 			awsAlias._options = { alias: 'myStage' };
-			awsAlias._alias = 'myStage';
+			awsAlias._alias = 'master';
+			slsStack1.Outputs.MasterAliasName = {
+				Value: 'master'
+			};
 
 			return expect(awsAlias.removeAlias(slsStack1, [], aliasStack2)).to.be.fulfilled
 			.then(() => BbPromise.all([
@@ -128,6 +137,9 @@ describe('removeAlias', () => {
 		});
 
 		it('should remove alias stack', () => {
+			slsStack1.Outputs.MasterAliasName = {
+				Value: 'master'
+			};
 			aliasApplyStackChangesStub.returns([ slsStack1, [ aliasStack2 ], aliasStack1 ]);
 			aliasCreateStackChangesStub.returns([ slsStack1, [ aliasStack2 ], aliasStack1 ]);
 			aliasRemoveAliasStackStub.returns([ slsStack1, [ aliasStack2 ], aliasStack1 ]);

--- a/test/updateAliasStack.test.js
+++ b/test/updateAliasStack.test.js
@@ -262,7 +262,6 @@ describe('updateAliasStack', () => {
 		it('should resolve in case no updates are performed', () => {
 			providerRequestStub.returns(BbPromise.resolve("done"));
 			monitorStackStub.rejects(new Error('No updates are to be performed.'));
-
 			return expect(awsAlias.updateAlias()).to.be.fulfilled
 			.then(() => expect(providerRequestStub).to.have.been.calledOnce);
 		});


### PR DESCRIPTION
This fixes #127 and will allow the master alias name to be selected by a command line option `sls deploy --masterAlias <masterAlias>`. The master alias name will be exported in the base stack as value and will be used upon removal of the stack.