### PR TITLE
Links update after repo move to serverless-heaven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
 /node_modules
 /coverage
 /.nyc_output
+
+# Jetbrains IDEs
+.idea/
+
+# Platform specific
+.DS_Store
+
+# Coverage directories used by tools like istanbul
+.nyc_output/
+coverage/
+
+# Code style tools
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[![Build Status](https://travis-ci.org/HyperBrain/serverless-aws-alias.svg?branch=master)](https://travis-ci.org/HyperBrain/serverless-aws-alias)
-[![Coverage Status](https://coveralls.io/repos/github/HyperBrain/serverless-aws-alias/badge.svg?branch=master)](https://coveralls.io/github/HyperBrain/serverless-aws-alias?branch=master)
-[![npm version](https://badge.fury.io/js/serverless-aws-alias.svg)](https://badge.fury.io/js/serverless-aws-alias)
-[![npm](https://img.shields.io/npm/dt/serverless-aws-alias.svg)](https://www.npmjs.com/package/serverless-aws-alias)
+[![Serverless][ico-serverless]][link-serverless]
+[![License][ico-license]][link-license]
+[![NPM][ico-npm]][link-npm]
+[![npm][ico-npm-downloads]][link-npm]
+[![Build Status][ico-build]][link-build]
+[![Coverage Status][ico-coverage]][link-coverage]
+[![Contributors][ico-contributors]][link-contributors]
 
 # Serverless AWS alias plugin
 
@@ -286,7 +289,7 @@ existing resource.
 ### Use with per alias resources
 
 **Currently this feature is not available. The Serverless framework does not
-support variable substitution in property names (see [#49](https://github.com/HyperBrain/serverless-aws-alias/issues/49)).
+support variable substitution in property names (see [#49][link-49]).
 As soon as this has been implemented there, this note will be removed.**
 
 There might be cases where you want to test with your private resources first,
@@ -469,55 +472,101 @@ and _serverless.service.provider.deployedAliasTemplates[]_.
 ## Version history
 
 * 1.7.1
-	* Restore compatibility with Serverless 1.27 [#120](https://github.com/HyperBrain/serverless-aws-alias/issues/120)
+	* Restore compatibility with Serverless 1.27 [#120][link-120]
 
 * 1.7.0
-	* Support existing custom authorizers [#101](https://github.com/HyperBrain/serverless-aws-alias/issues/101)
-	* Support domain-manager plugin [#110](https://github.com/HyperBrain/serverless-aws-alias/issues/110)
-	* Support pseudo-parameter plugin [#112](https://github.com/HyperBrain/serverless-aws-alias/issues/112)
-	* Show logs from arbitrary versions [#62](https://github.com/HyperBrain/serverless-aws-alias/issues/62), [#89](https://github.com/HyperBrain/serverless-aws-alias/issues/89)
+	* Support existing custom authorizers [#101][link-101]
+	* Support domain-manager plugin [#110][link-110]
+	* Support pseudo-parameter plugin [#112][link-112]
+	* Show logs from arbitrary versions [#62][link-62], [#89][link-89]
 
 * 1.6.1
- * Fixed custom authorizer references [#102](https://github.com/HyperBrain/serverless-aws-alias/pull/102)
- * Fixed broken DynamoDB stream deployments [#85](https://github.com/HyperBrain/serverless-aws-alias/issues/85)
+ * Fixed custom authorizer references [#102][link-102]
+ * Fixed broken DynamoDB stream deployments [#85][link-85]
  * Security: Updated moment
 
 * 1.6.0
- * Fixed issue with request authorizers [#96](https://github.com/HyperBrain/serverless-aws-alias/issues/96)
- * Support subscription to existing SNS topic [#94](https://github.com/HyperBrain/serverless-aws-alias/issues/94)
+ * Fixed issue with request authorizers [#96][link-96]
+ * Support subscription to existing SNS topic [#94][link-94]
 
 * 1.5.1
-  * Support prewarmup with the warmup plugin [#72](https://github.com/HyperBrain/serverless-aws-alias/issues/72)
-	* Support `_ - +` in alias names [#68](https://github.com/HyperBrain/serverless-aws-alias/issues/68)
-	* Support ANY method type with stage configuration [#80](https://github.com/HyperBrain/serverless-aws-alias/issues/80)
+  * Support prewarmup with the warmup plugin [#72][link-72]
+	* Support `_ - +` in alias names [#68][link-68]
+	* Support ANY method type with stage configuration [#80][link-80]
 
 * 1.5.0
-  * Support `serverless deploy function` [#29](https://github.com/HyperBrain/serverless-aws-alias/issues/29)
+  * Support `serverless deploy function` [#29][link-29]
 
 * 1.4.1
   * Fixed crash when using logs --tail
 
 * 1.4.0
-  * Add support for S3 server side encryption [#63](https://github.com/HyperBrain/serverless-aws-alias/issues/63)
-  * Add `serverless logs api` command to watch API logs [#60](https://github.com/HyperBrain/serverless-aws-alias/issues/60)
+  * Add support for S3 server side encryption [#63][link-63]
+  * Add `serverless logs api` command to watch API logs [#60][link-60]
 
 * 1.3.0
-  * Support full stage configuration at multiple levels [#57](https://github.com/HyperBrain/serverless-aws-alias/issues/57)
-  * Fix issue when trying to remove a stage completely [#56](https://github.com/HyperBrain/serverless-aws-alias/issues/56)
+  * Support full stage configuration at multiple levels [#57][link-57]
+  * Fix issue when trying to remove a stage completely [#56][link-56]
 
 * 1.2.1
-  * Fix issue when using a Cognito User Pools authorizer [#51](https://github.com/HyperBrain/serverless-aws-alias/issues/51)
-  * IAM roles of removed aliases are not deleted [#50](https://github.com/HyperBrain/serverless-aws-alias/issues/50)
+  * Fix issue when using a Cognito User Pools authorizer [#51][link-51]
+  * IAM roles of removed aliases are not deleted [#50][link-50]
   * Added note to README to state that per-alias resources do not work until fixed/added in Serverless
 
 * 1.2.0
-  * Fix issue when stage is specified as Serverless variable [#45](https://github.com/HyperBrain/serverless-aws-alias/issues/45)
-  * Add support for SNS Lambda subscriptions [#43](https://github.com/HyperBrain/serverless-aws-alias/issues/43)
-  * Add support for custom authorizers [#22](https://github.com/HyperBrain/serverless-aws-alias/issues/22)
+  * Fix issue when stage is specified as Serverless variable [#45][link-45]
+  * Add support for SNS Lambda subscriptions [#43][link-43]
+  * Add support for custom authorizers [#22][link-22]
 
 * 1.1.0
-  * Use stage variable in APIG [#40](https://github.com/HyperBrain/serverless-aws-alias/issues/40)
-  * Fix tail logging [#42](https://github.com/HyperBrain/serverless-aws-alias/issues/42)
+  * Use stage variable in APIG [#40][link-40]
+
+  * Fix tail logging [#42][link-42]
 
 
 * 1.0.0        Support "serverless logs" with aliases. First non-alpha!
+
+[ico-serverless]: http://public.serverless.com/badges/v3.svg
+[ico-license]: https://img.shields.io/github/license/serverless-heaven/serverless-webpack.svg
+[ico-npm]: https://img.shields.io/npm/v/serverless-aws-alias.svg
+[ico-build]: https://travis-ci.org/serverless-heaven/serverless-aws-alias.svg?branch=master
+[ico-coverage]: https://coveralls.io/repos/github/serverless-heaven/serverless-aws-alias/badge.svg?branch=master
+[ico-contributors]: https://img.shields.io/github/contributors/serverless-heaven/serverless-aws-alias.svg
+[ico-npm-downloads]: https://img.shields.io/npm/dt/serverless-aws-alias.svg
+
+[link-serverless]: http://www.serverless.com/
+[link-license]: ./blob/master/LICENSE
+[link-npm]: https://www.npmjs.com/package/serverless-aws-alias
+[link-build]: https://travis-ci.org/serverless-heaven/serverless-aws-alias
+[link-coverage]: https://coveralls.io/github/serverless-heaven/serverless-aws-alias?branch=master
+[link-contributors]: https://github.com/serverless-heaven/serverless-aws-alias/graphs/contributors
+
+
+[comment]: # (Referenced issues)
+
+[link-22]: https://github.com/serverless-heaven/serverless-aws-alias/issues/22
+[link-29]: https://github.com/serverless-heaven/serverless-aws-alias/issues/29
+[link-40]: https://github.com/serverless-heaven/serverless-aws-alias/issues/40
+[link-42]: https://github.com/serverless-heaven/serverless-aws-alias/issues/42
+[link-43]: https://github.com/serverless-heaven/serverless-aws-alias/issues/43
+[link-45]: https://github.com/serverless-heaven/serverless-aws-alias/issues/45
+[link-49]: https://github.com/serverless-heaven/serverless-aws-alias/issues/49
+[link-50]: https://github.com/serverless-heaven/serverless-aws-alias/issues/50
+[link-51]: https://github.com/serverless-heaven/serverless-aws-alias/issues/51
+[link-56]: https://github.com/serverless-heaven/serverless-aws-alias/issues/56
+[link-57]: https://github.com/serverless-heaven/serverless-aws-alias/issues/57
+[link-60]: https://github.com/serverless-heaven/serverless-aws-alias/issues/60
+[link-62]: https://github.com/serverless-heaven/serverless-aws-alias/issues/62
+[link-63]: https://github.com/serverless-heaven/serverless-aws-alias/issues/63
+[link-68]: https://github.com/serverless-heaven/serverless-aws-alias/issues/68
+[link-72]: https://github.com/serverless-heaven/serverless-aws-alias/issues/72
+[link-80]: https://github.com/serverless-heaven/serverless-aws-alias/issues/80
+[link-85]: https://github.com/serverless-heaven/serverless-aws-alias/issues/85
+[link-89]: https://github.com/serverless-heaven/serverless-aws-alias/issues/89
+[link-94]: https://github.com/serverless-heaven/serverless-aws-alias/issues/94
+[link-96]: https://github.com/serverless-heaven/serverless-aws-alias/issues/96
+[link-101]: https://github.com/serverless-heaven/serverless-aws-alias/issues/101
+[link-102]: https://github.com/serverless-heaven/serverless-aws-alias/issues/102
+[link-110]: https://github.com/serverless-heaven/serverless-aws-alias/issues/110
+[link-112]: https://github.com/serverless-heaven/serverless-aws-alias/issues/112
+[link-120]: https://github.com/serverless-heaven/serverless-aws-alias/issues/120

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git@github.com:hyperbrain/serverless-aws-alias.git"
+    "url": "https://github.com/serverless-heaven/serverless-aws-alias"
   },
   "scripts": {
     "test": "nyc ./node_modules/mocha/bin/_mocha \"test/**/*.js\" -R spec --recursive",
@@ -23,9 +23,9 @@
     "aliases"
   ],
   "bugs": {
-    "url": "https://github.com/HyperBrain/serverless-aws-alias/issues"
+    "url": "https://github.com/serverless-heaven/serverless-aws-alias/issues"
   },
-  "homepage": "https://github.com/HyperBrain/serverless-aws-alias#readme",
+  "homepage": "https://github.com/serverless-heaven/serverless-aws-alias#readme",
   "nyc": {
     "exclude": [
       "test/**/*.*"


### PR DESCRIPTION
Fixes: https://github.com/serverless-heaven/serverless-aws-alias/issues/160
`README.md` and `package.json` updated

PS: I'm not totally sure about coverage url, pls check.
PPS: gitignore updated with IDE, Platform, Coverage and Code style specific files