### PR TITLE
replace equals with startsWith in util functions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,7 @@ class Utils {
 	 * @returns {string}
 	 */
 	static getFunctionVersionName(versions, functionName) {
-		return _.find(_.keys(versions), version => version === `${functionName}LambdaVersion`);
+		return _.find(_.keys(versions), version => _.startsWith(version, `${functionName}LambdaVersion`));
 	}
 
 	/**
@@ -120,7 +120,7 @@ class Utils {
 	 * @returns {string}
 	 */
 	static getAliasVersionName(aliases, functionName) {
-		return _.find(_.keys(aliases), alias => alias === `${functionName}Alias`);
+		return _.find(_.keys(aliases), alias => _.startsWith(alias, `${functionName}Alias`));
 	}
 }
 


### PR DESCRIPTION
Fixes #159  by reverting code introduced in #162 
I overlooked that versions and alias will have a generated suffix. This will lead to errors, when using `===` instead of `_.startsWith`