### PR TITLE
Option to retain versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ alias, this option should not be used.)
 From now on you can reference the aliased versions on Lambda invokes with the
 stage qualifier. The aliased version is read only in the AWS console, so it is
 guaranteed that the environment and function parameters (memory, etc.) cannot
-be changed for a deployed version by accident, as it can be done with the 
+be changed for a deployed version by accident, as it can be done with the
 `$LATEST` qualifier.This adds an additional level of stability to your deployment
 process.
 
@@ -67,6 +67,12 @@ Example:
 ## Remove an alias
 
 See the `alias remove` command below.
+
+## Maintain versions
+
+By default, when you deploy, the version of the function gets assigned the retention policy of 'Delete'. This means any subsequent deploys will delete any version without an alias. This was done because you can no longer tell which alias it came from.
+
+There are usecases where retaining versions is less risky and as such, you can opt into retaining these versions by deploying with the `--retain` flag.
 
 ## Remove a service
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ See the `alias remove` command below.
 
 ## Maintain versions
 
-By default, when you deploy, the version of the function gets assigned the retention policy of 'Delete'. This means any subsequent deploys will delete any version without an alias. This was done because you can no longer tell which alias it came from.
+By default, when you deploy, the version of the function gets assigned the retention policy of 'Delete'. This means any subsequent deploys will delete any version without an alias. This was done because each lambda version has its own stack. That stack can contain differences in not only the function code, but resources and events. When an alias is removed from a version and the version of the lambda is not deleted, it is no longer possible to tell which stack it came from and which resources/events it was meant to work with. Therefore versions without aliases will get deleted on subsequent deploys.
 
 There are usecases where retaining versions is less risky and as such, you can opt into retaining these versions by deploying with the `--retain` flag.
 

--- a/lib/stackops/functions.js
+++ b/lib/stackops/functions.js
@@ -110,8 +110,9 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 			// Reference correct function name in version
 			version.Properties.FunctionName = { 'Fn::ImportValue': `${stackName}-${functionName}-LambdaFunctionArn` };
-			// With alias support we do not want to retain the versions
-			version.DeletionPolicy = 'Delete';
+
+			// With alias support we do not want to retain the versions unless explicitly asked to do so
+			version.DeletionPolicy = this._retain ? 'Retain' : 'Delete';
 
 			// Add alias to alias stack. Reference the version export in the stage stack
 			// to prevent version deletion.

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -20,6 +20,7 @@ module.exports = {
 		this._masterAlias = this._options.masterAlias || this._stage;
 		this._alias = this._options.alias || this._masterAlias;
 		this._stackName = this._provider.naming.getStackName();
+		this._retain = this._options.retain || false;
 
 		// Make alias available as ${self:provider.alias}
 		this._serverless.service.provider.alias = this._alias;


### PR DESCRIPTION
By default, versions are given the "Delete" retention policy. @HyperBrain gave a brief explanation why in issue #122. However, there are usecases and alias workflows where retaining previous versions is less risky. This PR adds a `--retain` flag which gives users an option for opting into retaining versions.