### PR TITLE
#136 - Fixed issue with eventSourceArn if not a resource reference

### DIFF
--- a/lib/stackops/events.js
+++ b/lib/stackops/events.js
@@ -32,31 +32,33 @@ module.exports = function(currentTemplate, aliasStackTemplates, currentAliasStac
 
 		// Make sure that the referenced resource is exported by the stageStack.
 		const resourceRef = utils.findAllReferences(_.get(subscription, 'Properties.EventSourceArn'));
-		// Build the export name
-		let resourceRefName = _.get(resourceRef, '[0].ref');
-		if (_.has(subscription.Properties, 'EventSourceArn.Fn::GetAtt')) {
-			const attribute = subscription.Properties.EventSourceArn['Fn::GetAtt'][1];
-			resourceRefName += attribute;
-		}
-		// Add the ref output to the stack if not already done.
-		stageStack.Outputs[resourceRefName] = {
-			Description: 'Alias resource reference',
-			Value: subscription.Properties.EventSourceArn,
-			Export: {
-				Name: `${stackName}-${resourceRefName}`
-			}
-		};
-		// Add the output to the referenced alias outputs
-		const aliasOutputs = JSON.parse(aliasStack.Outputs.AliasOutputs.Value);
-		aliasOutputs.push(resourceRefName);
-		aliasStack.Outputs.AliasOutputs.Value = JSON.stringify(aliasOutputs);
-		// Replace the reference with the cross stack reference
-		subscription.Properties.EventSourceArn = {};
+		if (resourceRef.length > 0) {
+		  // Build the export name
+		  let resourceRefName = _.get(resourceRef, '[0].ref');
+		  if (_.has(subscription.Properties, 'EventSourceArn.Fn::GetAtt')) {
+			  const attribute = subscription.Properties.EventSourceArn['Fn::GetAtt'][1];
+			  resourceRefName += attribute;
+		  }
+		  // Add the ref output to the stack if not already done.
+		  stageStack.Outputs[resourceRefName] = {
+			  Description: 'Alias resource reference',
+			  Value: subscription.Properties.EventSourceArn,
+			  Export: {
+				  Name: `${stackName}-${resourceRefName}`
+			 }
+		  };
+		  // Add the output to the referenced alias outputs
+		  const aliasOutputs = JSON.parse(aliasStack.Outputs.AliasOutputs.Value);
+		  aliasOutputs.push(resourceRefName);
+		  aliasStack.Outputs.AliasOutputs.Value = JSON.stringify(aliasOutputs);
+		  // Replace the reference with the cross stack reference
+		  subscription.Properties.EventSourceArn = {};
 
-		// Event source ARNs can be volatile - e.g. DynamoDB and must not be referenced
-		// with Fn::ImportValue which does not allow for changes. So we have to register
-		// them for delayed lookup until the base stack has been updated.
-		this.addDeferredOutput(`${stackName}-${resourceRefName}`, subscription.Properties, 'EventSourceArn');
+		  // Event source ARNs can be volatile - e.g. DynamoDB and must not be referenced
+		  // with Fn::ImportValue which does not allow for changes. So we have to register
+		  // them for delayed lookup until the base stack has been updated.
+		  this.addDeferredOutput(`${stackName}-${resourceRefName}`, subscription.Properties, 'EventSourceArn');
+		}
 
 		// Remove mapping from stage stack
 		delete stageStack.Resources[name];


### PR DESCRIPTION
This makes sure that the event source ARN is a reference to a resource defined in serverless.yml and not just an ARN to an existing resource, which is not defined in serverless.yml.
If it is an ARN to an existing resource, it does not modify the EventSourceArn