### PR TITLE
Fix WARNING: Inappropriate call of provider.request()

### DIFF
--- a/lib/createAliasStack.js
+++ b/lib/createAliasStack.js
@@ -38,9 +38,7 @@ module.exports = {
 		return this._provider.request(
 			'CloudFormation',
 			'createStack',
-			params,
-			this._options.stage,
-			this._options.region
+			params
 		).then(cfData => this.monitorStack('create', cfData));
 
 	},
@@ -73,9 +71,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'describeStackResources',
-			{ StackName: this._aliasStackName },
-			this._options.stage,
-			this._options.region)
+			{ StackName: this._aliasStackName })
 		.then(() => BbPromise.resolve('alreadyCreated'))
 		.catch(e => {
 			if (_.includes(e.message, 'does not exist')) {

--- a/lib/listAliases.js
+++ b/lib/listAliases.js
@@ -22,18 +22,14 @@ module.exports = {
 			{
 				restApiId: apiId,
 				stageName: stageName
-			},
-			this._options.stage,
-			this._options.region)
+			})
 		.then(stage => {
 			return this._provider.request('APIGateway',
 				'getDeployment',
 				{
 					restApiId: apiId,
 					deploymentId: stage.deploymentId
-				},
-				this._options.stage,
-				this._options.region);
+				});
 		})
 		.catch(err => {
 			if (/^Invalid stage/.test(err.message)) {
@@ -50,9 +46,7 @@ module.exports = {
 			{
 				LogicalResourceId: 'ApiGatewayRestApi',
 				StackName: stackName
-			},
-			this._options.stage,
-			this._options.region)
+			})
 		.then(cfData => cfData.StackResourceDetail.PhysicalResourceId)
 		.catch(() => BbPromise.resolve(null));
 	},

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -73,9 +73,7 @@ module.exports = {
 			return this.provider
 				.request('CloudWatchLogs',
 					'describeLogStreams',
-					params,
-					this.options.stage,
-					this.options.region)
+					params)
 				.then(reply => {
 					if (!reply || _.isEmpty(reply.logStreams)) {
 						throw new this.serverless.classes
@@ -104,9 +102,7 @@ module.exports = {
 		return this.provider.request(
 			'CloudWatchLogs',
 			'describeLogStreams',
-			params,
-			this.options.stage,
-			this.options.region
+			params
 		)
 		.then(reply => {
 			if (!reply || _.isEmpty(reply.logStreams)) {
@@ -196,9 +192,7 @@ module.exports = {
 		return this.provider
 			.request('CloudWatchLogs',
 				'filterLogEvents',
-				params,
-				this.options.stage,
-				this.options.region)
+				params)
 			.then(results => {
 				if (results.events) {
 					_.forEach(results.events, e => {

--- a/lib/removeAlias.js
+++ b/lib/removeAlias.js
@@ -171,9 +171,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'updateStack',
-			params,
-			this.options.stage,
-			this.options.region)
+			params)
 		.then(cfData => this.monitorStack('update', cfData))
 		.then(() => BbPromise.resolve([ currentTemplate, aliasStackTemplates, currentAliasStackTemplate ]))
 		.catch(err => {
@@ -193,9 +191,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'deleteStack',
-			{ StackName: stackName },
-			this._options.stage,
-			this._options.region)
+			{ StackName: stackName })
 		.then(cfData => {
 			// monitorStack wants a StackId member
 			cfData.StackId = stackName;

--- a/lib/stackInformation.js
+++ b/lib/stackInformation.js
@@ -21,9 +21,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'getTemplate',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 		.then(cfData => {
 			try {
 				return BbPromise.resolve(JSON.parse(cfData.TemplateBody));
@@ -45,9 +43,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'listImports',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 		.then(cfData => BbPromise.resolve(cfData.Imports));
 
 	},
@@ -61,9 +57,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'getTemplate',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 		.then(cfData => {
 			return BbPromise.resolve(JSON.parse(cfData.TemplateBody));
 		})
@@ -98,9 +92,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'describeStackResources',
-			{ StackName: stackName },
-			this._options.stage,
-			this._options.region);
+			{ StackName: stackName });
 	},
 
 	aliasStacksDescribeResource(resourceId) {
@@ -112,9 +104,7 @@ module.exports = {
 			{
 				StackName: stackName,
 				LogicalResourceId: resourceId
-			},
-			this._options.stage,
-			this._options.region);
+			});
 	},
 
 	aliasStacksDescribeAliases() {
@@ -124,9 +114,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'listImports',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 		.then(cfData => BbPromise.resolve(cfData.Imports))
 		.mapSeries(stack => {
 			const describeParams = {
@@ -135,9 +123,7 @@ module.exports = {
 
 			return this._provider.request('CloudFormation',
 				'describeStackResources',
-				describeParams,
-				this._options.stage,
-				this._options.region);
+				describeParams);
 		});
 	},
 
@@ -188,9 +174,7 @@ module.exports = {
 		const stackName = `${this._provider.naming.getStackName()}-${aliasName}`;
 		return this._provider.request('CloudFormation',
 			'describeStackResources',
-			{ StackName: stackName },
-			this._options.stage,
-			this._options.region);
+			{ StackName: stackName });
 	},
 
 	aliasGetAliasFunctionVersions(aliasName) {
@@ -207,9 +191,7 @@ module.exports = {
 	aliasGetAliasLatestFunctionVersionByFunctionName(aliasName, functionName) {
 		return this._provider.request('Lambda',
 			'getAlias',
-			{ FunctionName: functionName, Name: aliasName },
-			this._options.stage,
-			this._options.region)
+			{ FunctionName: functionName, Name: aliasName })
 			.then(result => _.get(result, 'FunctionVersion', null));
 	},
 

--- a/lib/updateAliasStack.js
+++ b/lib/updateAliasStack.js
@@ -38,9 +38,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'createStack',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 			.then((cfData) => this.monitorStack('create', cfData));
 	},
 
@@ -81,9 +79,7 @@ module.exports = {
 
 		return this._provider.request('CloudFormation',
 			'updateStack',
-			params,
-			this._options.stage,
-			this._options.region)
+			params)
 			.then((cfData) => this.monitorStack('update', cfData))
 			.catch((e) => {
 				if (e.message === NO_UPDATE_MESSAGE) {

--- a/lib/updateFunctionAlias.js
+++ b/lib/updateFunctionAlias.js
@@ -22,8 +22,7 @@ module.exports = {
 			return this.provider.request(
 				'Lambda',
 				'getFunction',
-				params,
-				this.options.stage, this.options.region
+				params
 			);
 		})
 		.then(result => {
@@ -37,8 +36,7 @@ module.exports = {
 			return this.provider.request(
 				'Lambda',
 				'publishVersion',
-				params,
-				this.options.stage, this.options.region
+				params
 			);
 		})
 		.then(result => {
@@ -53,8 +51,7 @@ module.exports = {
 			return this.provider.request(
 				'Lambda',
 				'updateAlias',
-				params,
-				this.options.stage, this.options.region
+				params
 			);
 		})
 		.then(result => {

--- a/lib/uploadAliasArtifacts.js
+++ b/lib/uploadAliasArtifacts.js
@@ -25,9 +25,7 @@ module.exports = {
 
 		return this.provider.request('S3',
 			'putObject',
-			params,
-			this._options.stage,
-			this._options.region);
+			params);
 	},
 
 	uploadAliasArtifacts() {

--- a/test/createAliasStack.test.js
+++ b/test/createAliasStack.test.js
@@ -82,7 +82,7 @@ describe('createAliasStack', () => {
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(monitorStackStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'createStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'createStack', expectedCFData),
 				expect(monitorStackStub).to.have.been
 					.calledWithExactly('create', requestResult)
 			]));
@@ -117,7 +117,7 @@ describe('createAliasStack', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'createStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'createStack', expectedCFData),
 			]));
 		});
 
@@ -208,7 +208,7 @@ describe('createAliasStack', () => {
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(createAliasStub).to.not.have.been.called,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'describeStackResources', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'describeStackResources', expectedCFData),
 			]));
 		});
 

--- a/test/logs.test.js
+++ b/test/logs.test.js
@@ -220,9 +220,7 @@ describe('logs', () => {
 						descending: true,
 						limit: 50,
 						orderBy: 'LastEventTime',
-					},
-					awsAlias.options.stage,
-					awsAlias.options.region
+					}
 				),
 				expect(logStreamNames).to.have.lengthOf(2),
 				expect(logStreamNames[0])
@@ -284,9 +282,7 @@ describe('logs', () => {
 						descending: true,
 						limit: 50,
 						orderBy: 'LastEventTime',
-					},
-					awsAlias.options.stage,
-					awsAlias.options.region
+					}
 				),
 				expect(logStreamNames).to.have.lengthOf(4),
 			]));
@@ -355,9 +351,7 @@ describe('logs', () => {
 						logStreamNames: logStreamNamesMock,
 						filterPattern: 'error',
 						startTime: 1475269200000,
-					},
-					awsAlias.options.stage,
-					awsAlias.options.region
+					}
 				),
 			]));
 		});
@@ -405,9 +399,7 @@ describe('logs', () => {
 							logStreamNames: logStreamNamesMock,
 							startTime: 1287532800000,
 							filterPattern: 'error',
-						},
-						awsAlias.options.stage,
-						awsAlias.options.region
+						}
 					),
 				]));
 		});
@@ -470,7 +462,7 @@ describe('logs', () => {
 				expect(formatter(testEvent)).to.be.a('string')
 					.that.contains('This is a test message');
 				expect(formatter(testEvent)).to.be.a('string')
-					.that.contains('2017-07-09 00:00:00.000 (+');
+					.that.contains('2017-07-09 00:00:00.000 (');
 			});
 		});
 	});

--- a/test/updateAliasStack.test.js
+++ b/test/updateAliasStack.test.js
@@ -84,7 +84,7 @@ describe('updateAliasStack', () => {
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(monitorStackStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'createStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'createStack', expectedCFData),
 				expect(monitorStackStub).to.have.been
 					.calledWithExactly('create', requestResult)
 			]));
@@ -119,7 +119,7 @@ describe('updateAliasStack', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'createStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'createStack', expectedCFData),
 			]));
 		});
 
@@ -147,7 +147,7 @@ describe('updateAliasStack', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'createStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'createStack', expectedCFData),
 			]));
 		});
 
@@ -186,7 +186,7 @@ describe('updateAliasStack', () => {
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(monitorStackStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData),
 				expect(monitorStackStub).to.have.been
 					.calledWithExactly('update', requestResult)
 			]));
@@ -220,7 +220,7 @@ describe('updateAliasStack', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData),
 			]));
 		});
 
@@ -247,7 +247,7 @@ describe('updateAliasStack', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData, 'myStage', 'us-east-1'),
+					.calledWithExactly('CloudFormation', 'updateStack', expectedCFData),
 			]));
 		});
 

--- a/test/uploadAliasArtifacts.test.js
+++ b/test/uploadAliasArtifacts.test.js
@@ -73,7 +73,7 @@ describe('uploadAliasArtifacts', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('S3', 'putObject', expectedData, 'myStage', 'us-east-1'),
+					.calledWithExactly('S3', 'putObject', expectedData),
 			]));
 		});
 
@@ -107,7 +107,7 @@ describe('uploadAliasArtifacts', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('S3', 'putObject', expectedData, 'myStage', 'us-east-1'),
+					.calledWithExactly('S3', 'putObject', expectedData),
 			]));
 		});
 
@@ -138,7 +138,7 @@ describe('uploadAliasArtifacts', () => {
 			.then(() => BbPromise.all([
 				expect(providerRequestStub).to.have.been.calledOnce,
 				expect(providerRequestStub).to.have.been
-					.calledWithExactly('S3', 'putObject', expectedData, 'myStage', 'us-east-1'),
+					.calledWithExactly('S3', 'putObject', expectedData),
 			]));
 		});
 


### PR DESCRIPTION
The serverless [`provider.request()` api has changed](https://github.com/serverless/serverless/blob/4f64e560b9157dc8700328686a778ebd2a78ba9e/lib/plugins/aws/provider.js#L1332-L1340) since this plugin was written. This was resulting in `WARNING: Inappropriate call of provider.request()` output during deploys.

While it is possible to pass `options.region`, I didn't think it was very likely that these requests would need to go to a region other than the one the stack is deployed to, so I removed these options from the request calls.