### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,12 +86,14 @@ class AwsAlias {
 							alias: {
 								usage: 'Name of the alias',
 								shortcut: 'a',
-								required: true
+								required: true,
+								type: 'string',
 							},
 							verbose: {
 								usage: 'Enable verbose output',
 								shortcut: 'v',
-								required: false
+								required: false,
+								type: 'boolean',
 							}
 						}
 					}


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - AwsAlias for "alias", "verbose"
```